### PR TITLE
Import image-froth as a component maintained in a separate repo

### DIFF
--- a/app/article/index.js
+++ b/app/article/index.js
@@ -15,7 +15,7 @@ const {
   uploadImgAsync,
   summarize
 } = require('../../helpers/submission')
-const { froth } = require('../../helpers/image_froth')
+const { imageFroth } = require('../../helpers/image_froth')
 const uploadRSSAndSitemap = require('../../upload_rss_sitemap')
 const multipartMiddleware = multipart()
 const articleApp = express()
@@ -140,7 +140,7 @@ articleApp.get('/rss', async (req, res) => {
   articleFeed.items = []
   articles.forEach(a => {
     const url = `https://www.analog.cafe/zine/${a.slug}`
-    const image = a.poster && froth({ src: a.poster })
+    const image = a.poster && imageFroth({ src: a.poster })
 
     // smarter name joiner with punctuation
     const authorNameList = authors => {

--- a/helpers/image_froth.js
+++ b/helpers/image_froth.js
@@ -1,75 +1,34 @@
 // tools
+const { froth } = require("@roast-cms/image-froth")
+
+// constants
 const IMAGE_FROTH_SERVER =
-  'https://res.cloudinary.com/analog-cafe/image/upload/'
-const IMAGE_FROTH_OPTIONS = 'c_scale,fl_progressive'
+  "https://res.cloudinary.com/analog-cafe/image/upload/"
+const IMAGE_FROTH_OPTIONS = "c_scale,fl_progressive"
 const IMAGE_FROTH_SIZES = {
-  t: '280',
-  s: '520',
-  m: '1268',
-  l: '1800'
+  t: "280",
+  s: "520",
+  m: "1268",
+  l: "1800"
 }
 
-// image-froth_1681956_9ad677d272a84ebc9360ad6199372f8b
-const froth = (options = {}) => {
-  let src = options.src
-  let size = options.size || 'm'
-  let type = options.type || 'jpg'
-  let crop = options.crop || 'none'
-
-  let width = IMAGE_FROTH_SIZES[size]
-  let height = null
-  let ratio = 0
-
-  // extension is passed in through id:
-  if (/[.]/.exec(src)) {
-    type = src.split('.').pop() // log extension
-    src = src.replace(/\.[^/.]+$/, '') // remove extension from file name
-  }
-
-  if (src.includes('image-froth') && !src.includes('/')) {
-    if (crop === 'none') {
-      src =
-        IMAGE_FROTH_SERVER +
-        IMAGE_FROTH_OPTIONS +
-        ',w_' +
-        width +
-        '/' +
-        src +
-        '.' +
-        type
-      ratio = src.split('image-froth_').pop().split('_').shift() / 1000000
-      height = Math.round(width / ratio, 1)
-    } else if (crop === 'square') {
-      ratio = 1
-      height = width
-      src =
-        IMAGE_FROTH_SERVER +
-        'c_fill,g_auto,w_' +
-        width +
-        ',h_' +
-        height +
-        '/' +
-        src +
-        '.' +
-        type
-    }
-  }
-  console.log({
-    src,
-    type,
-    ratio,
-    width,
-    height
-  })
-  return {
-    src,
-    type,
-    ratio,
-    width,
-    height
+const FROTH_CONSTANTS = {
+  // cloudinary server and subfolder location
+  server: "https://res.cloudinary.com/analog-cafe/image/upload/",
+  // transformations (array) for images (kept constant)
+  transformations: "c_scale,fl_progressive",
+  // all sizes are image widths; heights are relative
+  sizes: {
+    i: "40", // icon
+    t: "280", // tiny
+    s: "520", // small
+    m: "1268", // medium (required default)
+    l: "1800" // large
   }
 }
+
+const imageFroth = options => froth(options, FROTH_CONSTANTS)
 
 module.exports = {
-  froth
+  imageFroth
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/dmitrizzle/Analog.Cafe"
   },
   "dependencies": {
+    "@roast-cms/image-froth": "^0.1.0",
     "@sendgrid/mail": "6.1.3",
     "aws-sdk": "^2.130.0",
     "bluebird": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@roast-cms/image-froth@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@roast-cms/image-froth/-/image-froth-0.1.0.tgz#9ccd272b95b57d6724ed084d5b7dd41c3d1b56fa"
+
 "@sendgrid/client@^6.1.3":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-6.1.4.tgz#cee90801620a45e09f4bbb49d2cd5b3c69a44b5f"


### PR DESCRIPTION
`froth()` became a standardized function that's available in [this repo](https://github.com/roast-cms/image-froth). Since it's used by both the server and the front-end, and it could be useful in other Cloudinary projects it's best to maintain it separately.